### PR TITLE
introduce `jteVersion` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ jte{
     // create a temporary directory.
     // default value: null
     pluginGenerationDirectory = file("${project.buildDir}/generated-plugin")
+    
+    // the minimum version of JTE the generated plugin requires
+    // must be greater than version 2.0
+    jteVersion = '2.0'
 }
 
 // for a full list of configuration options, check out the

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JteExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JteExtension.groovy
@@ -65,4 +65,7 @@ abstract class JteExtension{
     @Optional
     abstract RegularFileProperty getPluginGenerationDirectory()
 
+    @Optional
+    abstract Property<String> getJteVersion()
+
 }

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JtePlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JtePlugin.groovy
@@ -15,6 +15,8 @@
 */
 package org.jenkinsci.gradle.plugins.jte
 
+import groovy.json.JsonSlurper
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.DependencyResolutionListener
@@ -28,8 +30,8 @@ class JtePlugin implements Plugin<Project>{
 
     @Override
     void apply(Project project){
-        addJteDependency(project)
         Object extension = JteExtension.configure(project)
+        addJteDependency(project, extension)
         // create a task "jte" that builds the plugin code and then use
         // the gradle-jpi-plugin to build the artifact
         project.plugins.apply(JpiPlugin)
@@ -44,12 +46,46 @@ class JtePlugin implements Plugin<Project>{
      * registers JTE as a dependency so that the generated plugin can compile
      * @param project
      */
-    void addJteDependency(Project project){
+    void addJteDependency(Project project, Object extension){
         project.getGradle().addListener(new DependencyResolutionListener() {
             @Override
             void beforeResolve(ResolvableDependencies resolvableDependencies) {
-                project.dependencies.add("implementation", 'org.jenkins-ci.plugins:templating-engine:2.5.2')
+                String jteVersion = "2.0"
+                if(extension.jteVersion.isPresent()){
+                    jteVersion = extension.jteVersion.get()
+                }
+                checkVersion(jteVersion)
+                project.dependencies.add("implementation", "org.jenkins-ci.plugins:templating-engine:${jteVersion}")
                 project.getGradle().removeListener(this)
+            }
+
+            void checkVersion(String jteVersion){
+                String major = jteVersion.split('\\.').first()
+                // ensure the major version is actually a number
+                if(!major.isNumber()){
+                    throw new GradleException("jteVersion '${jteVersion}' is not valid.")
+                }
+                // ensure the major version is >= 2
+                if(major.toInteger() < 2){
+                    throw new GradleException("jteVersion must be greater than release 2.0")
+                }
+                // ensure the specified version is actually a JTE release
+                if(!isValidJteVersion(jteVersion)){
+                    throw new GradleException("jteVersion '${jteVersion}' is not a JTE release.")
+                }
+            }
+
+            /**
+             * fetches the released versions in artifactory and ensure
+             * the provided version is valid
+             * @param version
+             * @return true if the version is valid, false otherwise
+             */
+            Boolean isValidJteVersion(String version){
+                URL url = "https://repo.jenkins-ci.org/artifactory/api/search/versions?g=org.jenkins-ci.plugins&a=templating-engine".toURL()
+                Object response = new JsonSlurper().parse(url)
+                Set<String> versions = response.results.collect{ it.version }
+                return version in versions
             }
 
             @Override

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JtePlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JtePlugin.groovy
@@ -84,7 +84,7 @@ class JtePlugin implements Plugin<Project>{
             Boolean isValidJteVersion(String version){
                 URL url = "https://repo.jenkins-ci.org/artifactory/api/search/versions?g=org.jenkins-ci.plugins&a=templating-engine".toURL()
                 Object response = new JsonSlurper().parse(url)
-                Set<String> versions = response.results.collect{ it.version }
+                Set<String> versions = response.results.collect{ entry -> entry.version }
                 return version in versions
             }
 

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jte/FunctionalTestSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jte/FunctionalTestSpec.groovy
@@ -107,6 +107,7 @@ class FunctionalTestSpec extends Specification {
         when:
         BuildResult result = test.runJteTask()
         then:
+        result.task(":jte").outcome == SUCCESS
         File hpi = new File("${test.projectDir}/build/libs/${test.pluginShortName}.hpi")
         assert test.readFileInHpi(hpi, "META-INF/MANIFEST.MF").contains("templating-engine:2.0")
     }
@@ -118,6 +119,7 @@ class FunctionalTestSpec extends Specification {
         when:
         BuildResult result = test.runJteTask()
         then:
+        result.task(":jte").outcome == SUCCESS
         File hpi = new File("${test.projectDir}/build/libs/${test.pluginShortName}.hpi")
         assert test.readFileInHpi(hpi, "META-INF/MANIFEST.MF").contains("templating-engine:2.5.2")
     }
@@ -129,6 +131,7 @@ class FunctionalTestSpec extends Specification {
         when:
         BuildResult result = test.runJteTask(true)
         then:
+        println result.output
         assert result.output.contains("jteVersion '18.9.1.1.1' is not a JTE release.")
     }
 
@@ -139,6 +142,7 @@ class FunctionalTestSpec extends Specification {
         when:
         BuildResult result = test.runJteTask(true)
         then:
+        println result.output
         assert result.output.contains("jteVersion must be greater than release 2.0")
     }
 

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jte/FunctionalTestSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jte/FunctionalTestSpec.groovy
@@ -93,13 +93,53 @@ class FunctionalTestSpec extends Specification {
 
         when:
         BuildResult result = test.runJteTask()
-        println test.projectDir
 
         then:
         result.task(":jte").outcome == SUCCESS
         File source = new File(test.pluginDir, "src/main/groovy/LibrarySourcePlugin.groovy")
         assert source.exists()
         assert source.text.contains("@Symbol('myCustomName')")
+    }
+
+    def "not setting jteVersion results in a dependency on 2.0"(){
+        given:
+        test.createStep("example","step","void call(){}")
+        when:
+        BuildResult result = test.runJteTask()
+        then:
+        File hpi = new File("${test.projectDir}/build/libs/${test.pluginShortName}.hpi")
+        assert test.readFileInHpi(hpi, "META-INF/MANIFEST.MF").contains("templating-engine:2.0")
+    }
+
+    def "setting jteVersion changes the generated plugin dependency"(){
+        given:
+        test.setJteVersion("2.5.2")
+        test.createStep("example","step","void call(){}")
+        when:
+        BuildResult result = test.runJteTask()
+        then:
+        File hpi = new File("${test.projectDir}/build/libs/${test.pluginShortName}.hpi")
+        assert test.readFileInHpi(hpi, "META-INF/MANIFEST.MF").contains("templating-engine:2.5.2")
+    }
+
+    def "invalid jteVersion throws exception"(){
+        given:
+        test.setJteVersion("18.9.1.1.1")
+        test.createStep("example","step","void call(){}")
+        when:
+        BuildResult result = test.runJteTask(true)
+        then:
+        assert result.output.contains("jteVersion '18.9.1.1.1' is not a JTE release.")
+    }
+
+    def "jteVersion < 2.0 throws exception"(){
+        given:
+        test.setJteVersion("1.7.1")
+        test.createStep("example","step","void call(){}")
+        when:
+        BuildResult result = test.runJteTask(true)
+        then:
+        assert result.output.contains("jteVersion must be greater than release 2.0")
     }
 
 }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jte/JteSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jte/JteSpec.groovy
@@ -163,7 +163,6 @@ class JteSpec extends Specification {
         then: "the pipeline succeeds"
         jenkins.assertBuildStatusSuccess(run)
         jenkins.assertLogContains("step ran", run)
-
     }
 
     @Issue("https://github.com/jenkinsci/gradle-jte-plugin/issues/1")

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jte/TestUtil.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jte/TestUtil.groovy
@@ -104,9 +104,9 @@ class TestUtil {
             baseDirectory = file("${baseDirectory}")
             ${jteVersion ? "jteVersion = '${jteVersion}'" : ""}
         }
-        
+
         ${buildFileAppends}
-        """
+        """.stripIndent()
 
         GradleRunner jte = GradleRunner.create()
             .withProjectDir(projectDir)
@@ -216,8 +216,8 @@ class TestUtil {
         ZipInputStream zipStream = new ZipInputStream(hpi.toURI().toURL().openStream())
         ZipEntry zipEntry = zipStream.getNextEntry()
         while(zipEntry != null){
-            String _path = zipEntry.getName()
-            if(path != _path){
+            String entryPath = zipEntry.getName()
+            if(path != entryPath){
                 zipEntry = zipStream.getNextEntry()
                 continue
             }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jte/TestUtil.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jte/TestUtil.groovy
@@ -30,6 +30,11 @@ import org.gradle.testkit.runner.GradleRunner
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
 import org.jvnet.hudson.test.JenkinsRule
 
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
+import java.nio.charset.StandardCharsets
+
 class TestUtil {
 
     /**
@@ -72,6 +77,11 @@ class TestUtil {
      */
     String buildFileAppends
 
+    /**
+     * The version of jte the generated plugin should depend on
+     */
+    String jteVersion
+
     BuildResult runJteTask(boolean shouldFail = false){
         pluginShortName = pluginShortName ?: UUID.randomUUID().toString().replaceAll("-","")
 
@@ -92,6 +102,7 @@ class TestUtil {
             pluginGenerationDirectory = file('${pluginDir}')
             ${pluginSymbol ? "pluginSymbol = '${pluginSymbol}'" : ""}
             baseDirectory = file("${baseDirectory}")
+            ${jteVersion ? "jteVersion = '${jteVersion}'" : ""}
         }
         
         ${buildFileAppends}
@@ -116,6 +127,10 @@ class TestUtil {
     void setBaseDirectory(String path){
         baseDirectory = new File(projectDir, path)
         baseDirectory.mkdirs()
+    }
+
+    void setJteVersion(String jteVersion){
+        this.jteVersion = jteVersion
     }
 
     void createStep(String libraryName, String stepName, String stepText){
@@ -194,6 +209,29 @@ class TestUtil {
             w.getShortName() == pluginShortName
         }
         return p ? p.getClass().getDeclaringClass().newInstance() : null
+    }
+
+    String readFileInHpi(File hpi, String path){
+        ZipFile zipFile = new ZipFile(hpi)
+        ZipInputStream zipStream = new ZipInputStream(hpi.toURI().toURL().openStream())
+        ZipEntry zipEntry = zipStream.getNextEntry()
+        while(zipEntry != null){
+            String _path = zipEntry.getName()
+            if(path != _path){
+                zipEntry = zipStream.getNextEntry()
+                continue
+            }
+            InputStream stream = zipFile.getInputStream(zipEntry)
+            ArrayList lines = []
+            try{
+                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))
+                String line
+                while((line = bufferedReader.readLine()) != null){
+                    lines << line
+                }
+            } catch(ignored){}
+            return lines.join("\n")
+        }
     }
 
 }


### PR DESCRIPTION
fixes #2 by introducing a configuration option `jteVersion` to the `jte{}` block. 

the version provided will be the minimum version of JTE that the generated plugin requires.