### PR TITLE
Favor constraints, withDependencies

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JteExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JteExtension.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.Optional
 abstract class JteExtension{
 
     static final String DEFAULT_BASE_DIRECTORY = "libraries"
+    static final String DEFAULT_JTE_VERSION = "2.0"
 
     /**
      * Registers the `jte` Extension and defines configuration conventions
@@ -38,6 +39,7 @@ abstract class JteExtension{
         Object extension = project.extensions.create('jte', JteExtension)
         // set the default value of `jte.baseDirectory` to `libraries`
         extension.baseDirectory.convention(project.getLayout().getProjectDirectory().file(DEFAULT_BASE_DIRECTORY))
+        extension.jteVersion.convention(DEFAULT_JTE_VERSION)
         return extension
     }
 

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JtePlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JtePlugin.groovy
@@ -47,10 +47,7 @@ class JtePlugin implements Plugin<Project>{
      */
     void addJteDependency(Project project, Object extension) {
         project.configurations.getByName("implementation").withDependencies { dependencies ->
-            String jteVersion = "2.0"
-            if (extension.jteVersion.isPresent()) {
-                jteVersion = extension.jteVersion.get()
-            }
+            String jteVersion = extension.jteVersion.get()
             checkVersion(jteVersion)
             String gav = "org.jenkins-ci.plugins:templating-engine:${jteVersion}"
             Dependency templatingEngine = project.dependencies.create(gav)

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JtePlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jte/JtePlugin.groovy
@@ -19,8 +19,7 @@ import groovy.json.JsonSlurper
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.DependencyResolutionListener
-import org.gradle.api.artifacts.ResolvableDependencies
+import org.gradle.api.artifacts.Dependency
 import org.jenkinsci.gradle.plugins.jpi.JpiPlugin
 
 /**
@@ -46,51 +45,47 @@ class JtePlugin implements Plugin<Project>{
      * registers JTE as a dependency so that the generated plugin can compile
      * @param project
      */
-    void addJteDependency(Project project, Object extension){
-        project.getGradle().addListener(new DependencyResolutionListener() {
-            @Override
-            void beforeResolve(ResolvableDependencies resolvableDependencies) {
-                String jteVersion = "2.0"
-                if(extension.jteVersion.isPresent()){
-                    jteVersion = extension.jteVersion.get()
-                }
-                checkVersion(jteVersion)
-                project.dependencies.add("implementation", "org.jenkins-ci.plugins:templating-engine:${jteVersion}")
-                project.getGradle().removeListener(this)
+    void addJteDependency(Project project, Object extension) {
+        project.configurations.getByName("implementation").withDependencies { dependencies ->
+            String jteVersion = "2.0"
+            if (extension.jteVersion.isPresent()) {
+                jteVersion = extension.jteVersion.get()
             }
+            checkVersion(jteVersion)
+            String gav = "org.jenkins-ci.plugins:templating-engine:${jteVersion}"
+            Dependency templatingEngine = project.dependencies.create(gav)
+            templatingEngine.because('''Added by io.jenkins.jte plugin using `jte.jteVersion`''')
+            dependencies.add(templatingEngine)
+        }
+    }
 
-            void checkVersion(String jteVersion){
-                String major = jteVersion.split('\\.').first()
-                // ensure the major version is actually a number
-                if(!major.isNumber()){
-                    throw new GradleException("jteVersion '${jteVersion}' is not valid.")
-                }
-                // ensure the major version is >= 2
-                if(major.toInteger() < 2){
-                    throw new GradleException("jteVersion must be greater than release 2.0")
-                }
-                // ensure the specified version is actually a JTE release
-                if(!isValidJteVersion(jteVersion)){
-                    throw new GradleException("jteVersion '${jteVersion}' is not a JTE release.")
-                }
-            }
+    void checkVersion(String jteVersion){
+        String major = jteVersion.split('\\.').first()
+        // ensure the major version is actually a number
+        if(!major.isNumber()){
+            throw new GradleException("jteVersion '${jteVersion}' is not valid.")
+        }
+        // ensure the major version is >= 2
+        if(major.toInteger() < 2){
+            throw new GradleException("jteVersion must be greater than release 2.0")
+        }
+        // ensure the specified version is actually a JTE release
+        if(!isValidJteVersion(jteVersion)){
+            throw new GradleException("jteVersion '${jteVersion}' is not a JTE release.")
+        }
+    }
 
-            /**
-             * fetches the released versions in artifactory and ensure
-             * the provided version is valid
-             * @param version
-             * @return true if the version is valid, false otherwise
-             */
-            Boolean isValidJteVersion(String version){
-                URL url = "https://repo.jenkins-ci.org/artifactory/api/search/versions?g=org.jenkins-ci.plugins&a=templating-engine".toURL()
-                Object response = new JsonSlurper().parse(url)
-                Set<String> versions = response.results.collect{ entry -> entry.version }
-                return version in versions
-            }
-
-            @Override
-            void afterResolve(ResolvableDependencies resolvableDependencies) {}
-        })
+    /**
+     * fetches the released versions in artifactory and ensure
+     * the provided version is valid
+     * @param version
+     * @return true if the version is valid, false otherwise
+     */
+    Boolean isValidJteVersion(String version){
+        URL url = "https://repo.jenkins-ci.org/artifactory/api/search/versions?g=org.jenkins-ci.plugins&a=templating-engine".toURL()
+        Object response = new JsonSlurper().parse(url)
+        Set<String> versions = response.results.collect{ entry -> entry.version }
+        return version in versions
     }
 
 }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jte/FunctionalTestSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jte/FunctionalTestSpec.groovy
@@ -19,6 +19,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
 
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
 import spock.lang.Specification
 
 class FunctionalTestSpec extends Specification {
@@ -144,6 +145,21 @@ class FunctionalTestSpec extends Specification {
         then:
         println result.output
         assert result.output.contains("jteVersion must be greater than release 2.0")
+    }
+
+    def "dependencyInsight shows where templating-engine came from"() {
+        given:
+        test.setJteVersion("2.5.2")
+        test.createStep("example", "step", "void call(){}")
+        test.createJteBuildFile()
+        when:
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(test.projectDir)
+                .withArguments("dependencyInsight", "--configuration", "compileClasspath", "--dependency", "templating-engine")
+                .withPluginClasspath()
+                .build()
+        then:
+        result.output.contains("- Was requested : Added by io.jenkins.jte plugin using `jte.jteVersion`")
     }
 
 }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jte/TestUtil.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jte/TestUtil.groovy
@@ -83,6 +83,17 @@ class TestUtil {
     String jteVersion
 
     BuildResult runJteTask(boolean shouldFail = false){
+        createJteBuildFile()
+
+        GradleRunner jte = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("jte")
+            .withPluginClasspath()
+
+        return shouldFail ? jte.buildAndFail() : jte.build()
+    }
+
+    void createJteBuildFile() {
         pluginShortName = pluginShortName ?: UUID.randomUUID().toString().replaceAll("-","")
 
         File buildFile = new File(projectDir, "build.gradle")
@@ -107,13 +118,6 @@ class TestUtil {
 
         ${buildFileAppends}
         """.stripIndent()
-
-        GradleRunner jte = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("jte")
-            .withPluginClasspath()
-
-        return shouldFail ? jte.buildAndFail() : jte.build()
     }
 
     void appendToBuildFile(String text){


### PR DESCRIPTION
Hi @steven-terrana, very cool plugin. I had a couple suggestions I wanted to share.

Configurations expose [`withDependencies`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/Configuration.html#withDependencies-org.gradle.api.Action-), which is a little simpler than managing dependency resolution listeners.

It's also possible to add a reason to the dependency, which shows up in `dependencyInsight`. This is super helpful in builds where there are tons of sources for dependency opinions. Here's an example of what it looks like:

<details>
<summary>
<code>./gradlew dependencyInsight --configuration compileClasspath --dependency templating-engine</code>
</summary>
<pre>
> Task :dependencyInsight
      org.jenkins-ci.plugins:templating-engine:2.5.2
         variant "apiElements" [
            org.gradle.category            = library (not requested)
            org.gradle.dependency.bundling = external
            org.gradle.jvm.version         = 8 (compatible with: 11)
            org.gradle.libraryelements     = jar (compatible with: classes+resources)
            org.gradle.usage               = java-api
            org.gradle.status              = release (not requested)
         ]
         Selection reasons:
            - Was requested : Added by io.jenkins.jte plugin using `jte.jteVersion`
       
      org.jenkins-ci.plugins:templating-engine:2.5.2
      \--- compileClasspath       
</pre>
</details>

Gradle provides this really nice constraint mechanism where we can reject anything lower than 2.0 with a reason that shows up in the build failure.

<details>
<summary>How v1.7.1 Fails</summary>
<pre>
* What went wrong:
      Execution failed for task ':compileGroovy'.
      > Could not resolve all files for configuration ':compileClasspath'.
         > Could not resolve org.jenkins-ci.plugins:templating-engine:1.7.1.
           Required by:
               project :
            > Cannot find a version of 'org.jenkins-ci.plugins:templating-engine' that satisfies the version constraints: 
                 Dependency path ':groovy-generated-6111471077836254507-tmpdir:unspecified' --> 'org.jenkins-ci.plugins:templating-engine:1.7.1' because of the following reason: Added by io.jenkins.jte plugin using `jte.jteVersion`
                 Constraint path ':groovy-generated-6111471077836254507-tmpdir:unspecified' --> 'org.jenkins-ci.plugins:templating-engine:{reject (,2.0)}' because of the following reason: jteVersion must be greater than release 2.0
</pre>
</details>

Not implemented here, but something to consider is removing the `checkVersion` logic. If this were removed the message would not be as nice (it would always say not found), but it would only check the configured repositories. Right now it will always reach out to the public Jenkins repository, which means every build will have a hard dependency on this particular url.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
